### PR TITLE
Change urgency to normal except when disconnected

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var ERROR_MESSAGE    = 'Something unexpected happened...';
 var NotifySendReporter = function(helper, logger, config) {
   var log = logger.create('reporter.notify-send');
 
-  var sys = require('sys')
+  var sys = require('sys');
   var exec = require('child_process').exec;
 
   function puts(error, stdout, stderr) {
@@ -46,15 +46,15 @@ var NotifySendReporter = function(helper, logger, config) {
     var results = browser.lastResult;
     var time = helper.formatTimeInterval(results.totalTime);
 
-    if (results.disconnected || results.error) {
+    if (results.disconnected) {
       return notifySend(ERROR_TITLE, ERROR_MESSAGE, 'critical', ERROR_ICON);
+    } else if (results.error) {
+      return notifySend(ERROR_TITLE, ERROR_MESSAGE, 'normal', ERROR_ICON);
+    } else if (results.failed) {
+      return notifySend(FAIL_TITLE, util.format(FAIL_MESSAGE, results.failed, results.total, time), 'normal', FAIL_ICON);
+    } else {
+      return notifySend(SUCCESS_TITLE, util.format(SUCCESS_MESSAGE, results.success, time), 'normal', SUCCESS_ICON);
     }
-
-    if (results.failed) {
-      return notifySend(FAIL_TITLE, util.format(FAIL_MESSAGE, results.failed, results.total, time), 'critical', FAIL_ICON);
-    }
-
-    return notifySend(SUCCESS_TITLE, util.format(SUCCESS_MESSAGE, results.success, time), 'normal', SUCCESS_ICON);
   };
 };
 


### PR DESCRIPTION
I propose this PR because, for example in Linux Mint, when you get a fail notification with urgency critical, the notification doesn't fade past a few seconds, and you have to close it manually. With this PR, the fails and errors get notified but they also fade away, making them more useful IMHO.
